### PR TITLE
Add LispJs REPL

### DIFF
--- a/bin/lispjs
+++ b/bin/lispjs
@@ -1,39 +1,43 @@
 #!/usr/bin/env node
 
+var repl = require('./repl');
+var compile = require('../lib/compile');
 var pkginfo = require('pkginfo')(module, 'version');
 var argv = require('optimist').argv;
 var fs = require('fs');
 
-if (typeof argv._[0] == 'undefined' || typeof argv.o == 'undefined') {
+if (!argv._.length) {
+  repl();
+} else if (typeof argv.o == 'undefined') {
   console.log("LispJS " + module.exports.version);
   console.log("Usage: " + argv['$0'] + " -o outputfile.js inputfile.lispjs");
-  process.exit(0);
+} else {
+  main();
 }
 
-fs.readFile(argv._[0], 'utf8', function(err, data) {
+function main() {
+  fs.readFile(argv._[0], 'utf8', function(err, data) {
 
-  if (err) {
-    console.log("Error opening input file");
-    process.exit(1)
-  }
+    if (err) {
+      console.log("Error opening input file");
+      process.exit(1)
+    }
 
-  var parser = require('../lib/syntax');
-  try {
-    var sTree = parser.parse(data);
-  } catch(err) {
-    console.log(err);
-    process.exit(1);
-  }
-  var semErrors = require('../lib/semantic_analyzer').getSemanticErrors(sTree);
-  var code = require('../lib/code_generator').generateCodeForList(sTree);
-  debugger;
-  fs.readFile(__dirname+"/../lib/lispjsfuncs.js", function(error, lispfuncsCode) {
-    var minifiedCode = require("uglify-js").minify(lispfuncsCode + "\n" + code, {fromString: true}).code;
-    fs.writeFile(argv.o, minifiedCode, function(err) {
-      if (err) {
-        console.log("Error writing file "+ argv.o + ": " + err);
-        process.exit(2)
-      }
+    try {
+      var code = compile(data);
+    } catch(err) {
+      console.log(err);
+      process.exit(1);
+    }
+
+    fs.readFile(__dirname+"/../lib/lispjsfuncs.js", function(error, lispfuncsCode) {
+      var minifiedCode = require("uglify-js").minify(lispfuncsCode + "\n" + code, {fromString: true}).code;
+      fs.writeFile(argv.o, minifiedCode, function(err) {
+        if (err) {
+          console.log("Error writing file "+ argv.o + ": " + err);
+          process.exit(2)
+        }
+      });
     });
   });
-});
+}

--- a/bin/repl.js
+++ b/bin/repl.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var compile = require('../lib/compile');
+var LispJs = require('../lib/lispjsfuncs').LispJs;
+var Repl = require('repl');
+var vm = require('vm');
+
+module.exports = function () {
+  var sandbox = {LispJs: LispJs};
+  vm.createContext(sandbox);
+
+  var repl = Repl.start({
+    useGlobal: true,
+    eval: function (expr, context, filename, cb) {
+      try {
+        var code = compile(expr);
+        var value = vm.runInContext(code, sandbox);
+        cb(null, value);
+      } catch (err) {
+        cb(err);
+      }
+    }
+  });
+};

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var parser = require('./syntax');
+var analyzer = require('../lib/semantic_analyzer');
+var codegen = require('../lib/code_generator');
+
+module.exports = function (source) {
+  var sTree = parser.parse(source);
+  var semErrors = analyzer.getSemanticErrors(sTree);
+  codegen.clearCode();
+  var code = codegen.generateCodeForList(sTree);
+  return code;
+};


### PR DESCRIPTION
This patch adds REPL for LispJs.

REPL is activated if `bin/lispjs` runs with no source file. This initial implementation compiles lines one by one in a separate context and prints errors and return values. REPL allows for rapid experimentation and feel of the language.

To prevent repeating main compilation logic I moved it to a separate module and require it from both main binary and REPL.
